### PR TITLE
Google common: user access credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We follow the standard GitHub [fork & pull](https://help.github.com/articles/using-pull-requests/#fork--pull) approach to pull requests. Just fork the official repo, develop in a branch, and submit a PR!
 
-You're always welcome to submit your PR straight away and start the discussion (without reading the rest of this wonderful doc, or the README.md). The goal of these notes is to make your experience contributing to Alpkka as smooth and pleasant as possible. We're happy to guide you through the process once you've submitted your PR.
+You're always welcome to submit your PR straight away and start the discussion (without reading the rest of this wonderful doc, or the README.md). The goal of these notes is to make your experience contributing to Alpakka as smooth and pleasant as possible. We're happy to guide you through the process once you've submitted your PR.
 
 # The Akka Community
 

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -33,6 +33,22 @@ alpakka.google {
     # Timeout for blocking call during settings initialization to compute engine metadata server
     compute-engine.timeout = 1s
 
+    user-access {
+      project-id = ""
+      client-id = ""
+      client-secret = ""
+      refresh-token = ""
+
+      # Resolves a path to the well-known credentials file
+      # See https://github.com/googleapis/google-auth-library-java/blob/master/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java#L237
+      path = ${user.home}/.config
+      path = ${?APPDATA} # Windows-only
+      path = ${alpakka.google.credentials.user-access.path}/gcloud
+      path = ${?CLOUDSDK_CONFIG}
+      path = ${alpakka.google.credentials.user-access.path}/application_default_credentials.json
+      path = ${?GOOGLE_APPLICATION_CREDENTIALS}
+    }
+
     none {
       project-id = "<no-project-id>"
       token = "<no-token>"

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessCredentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessCredentials.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.auth
+
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.InternalApi
+import akka.stream.Materializer
+import akka.stream.alpakka.google.RequestSettings
+import com.typesafe.config.Config
+import spray.json.DefaultJsonProtocol._
+import spray.json.{JsonParser, RootJsonFormat}
+
+import java.time.Clock
+import scala.concurrent.Future
+import scala.io.Source
+
+@InternalApi
+private[alpakka] object UserAccessCredentials {
+
+  def apply(clientId: String, clientSecret: String, refreshToken: String, projectId: String)(
+      implicit system: ClassicActorSystemProvider
+  ): Credentials = {
+    require(
+      clientId.nonEmpty && clientSecret.nonEmpty && refreshToken.nonEmpty && projectId.nonEmpty,
+      "User access credentials requires that client id, client secret, refresh token, and project id are defined."
+    )
+    new UserAccessCredentials(clientId, clientSecret, refreshToken, projectId)
+  }
+
+  def apply(c: Config)(implicit system: ClassicActorSystemProvider): Credentials = {
+    if (c.getString("client-id").nonEmpty) {
+      apply(
+        clientId = c.getString("client-id"),
+        clientSecret = c.getString("client-secret"),
+        refreshToken = c.getString("refresh-token"),
+        projectId = c.getString("project-id")
+      )
+    } else {
+      val src = Source.fromFile(c.getString("path"))
+      val credentials = JsonParser(src.mkString).convertTo[UserAccessCredentialsFile]
+      src.close()
+      apply(
+        clientId = credentials.client_id,
+        clientSecret = credentials.client_secret,
+        refreshToken = credentials.refresh_token,
+        projectId = credentials.quota_project_id
+      )
+    }
+  }
+
+  final case class UserAccessCredentialsFile(client_id: String,
+                                             client_secret: String,
+                                             refresh_token: String,
+                                             quota_project_id: String)
+  implicit val userAccessCredentialsFormat: RootJsonFormat[UserAccessCredentialsFile] = jsonFormat4(
+    UserAccessCredentialsFile
+  )
+}
+
+@InternalApi
+private final class UserAccessCredentials(clientId: String,
+                                          clientSecret: String,
+                                          refreshToken: String,
+                                          projectId: String)(
+    implicit mat: Materializer
+) extends OAuth2Credentials(projectId) {
+
+  override protected def getAccessToken()(implicit mat: Materializer,
+                                          settings: RequestSettings,
+                                          clock: Clock): Future[AccessToken] = {
+    UserAccessMetadata.getAccessToken(clientId, clientSecret, refreshToken)
+  }
+}

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessMetadata.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessMetadata.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.auth
+
+import akka.annotation.InternalApi
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{FormData, HttpRequest}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+
+import java.time.Clock
+import scala.concurrent.Future
+
+@InternalApi
+private[auth] object UserAccessMetadata {
+  private val tokenUrl = "https://accounts.google.com/o/oauth2/token"
+  private val `Metadata-Flavor` = RawHeader("Metadata-Flavor", "Google")
+
+  private def tokenRequest(clientId: String, clientSecret: String, refreshToken: String): HttpRequest = {
+    val entity = FormData(
+      "client_id" -> clientId,
+      "client_secret" -> clientSecret,
+      "refresh_token" -> refreshToken,
+      "grant_type" -> "refresh_token"
+    ).toEntity
+    HttpRequest(method = POST, uri = tokenUrl, entity = entity).addHeader(`Metadata-Flavor`)
+  }
+
+  def getAccessToken(clientId: String, clientSecret: String, refreshToken: String)(
+      implicit mat: Materializer,
+      clock: Clock
+  ): Future[AccessToken] = {
+    import SprayJsonSupport._
+    import mat.executionContext
+    implicit val system = mat.system
+    for {
+      response <- Http().singleRequest(tokenRequest(clientId, clientSecret, refreshToken))
+      token <- Unmarshal(response.entity).to[AccessToken]
+    } yield token
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
Our devs normally acquire credentials through `gcloud auth application-default login` on their personal computers. This creates a file in the well-known credentials file location. 

We already try to parse the file found in this location into a service account credentials file. However, credentials acquired this way will have a different format and can not be used as service account credentials. In addition, tokens are obtained a bit differently as we have to use a refresh token and a different endpoint.